### PR TITLE
Fixes issues on Japanese/Korean/Chinese file name

### DIFF
--- a/unique-uploaded-media-name.php
+++ b/unique-uploaded-media-name.php
@@ -93,7 +93,6 @@ function unique_uploaded_media_name($filename) {
 
 	$sanitized_filename = str_replace(array_keys($invalid), array_values($invalid), $sanitized_filename);
 
-	$sanitized_filename = preg_replace('/[^A-Za-z0-9-\. ]/', '', $sanitized_filename);
 	$sanitized_filename = preg_replace('/\.(?=.*\.)/', '', $sanitized_filename);
 	$sanitized_filename = preg_replace('/-+/', '-', $sanitized_filename);
 	$sanitized_filename = str_replace('-.', '.', $sanitized_filename);


### PR DESCRIPTION
For #1 
Example:
If `$sanitized_filename = '私はウクライナをサポートしています.jpg;'`
after `$sanitized_filename = remove_accents($filename); // Convert to ASCII`
the filename would be `.jpg`
Since `$sanitized_filename = remove_accents($filename); // Convert to ASCII` can substitute most weird characters,
please consider to remove `$sanitized_filename = remove_accents($filename); // Convert to ASCII` for Japanese/Korean/Chinese friendly.