### PR TITLE
Fixes conflicts with WPForms plugin

### DIFF
--- a/unique-uploaded-media-name.php
+++ b/unique-uploaded-media-name.php
@@ -102,8 +102,17 @@ function unique_uploaded_media_name($filename) {
 	$info = pathinfo($filename);
 	$ext  = empty($info['extension']) ? '' : '.' . $info['extension'];
 	$name = basename($sanitized_filename, $ext);
-
-	return $name . '-' . UniqueUploadedMediaName::stringTen() . $ext;
+	
+	// These extensions are picked accroding to https://wordpress.com/support/accepted-filetypes
+	$media_extensions = ['jpg', 'jpeg', 'png', 'ico', 'gif', 'webp', 'svg', 'mp3', 'm4a', 'ogg', 'wav', 'mp4', 'm4v', 'mov', 'wmv', 'avi', 'mpg', 'ogv', '3gp', '3g2', 'vtt'];
+	
+	foreach ($media_extensions as &$value) {
+		if ($info['extension'] == $value) {
+			return $name . '-' . UniqueUploadedMediaName::stringTen() . $ext;
+		}
+	}
+	
+	return $name . $ext;
 }
 
 add_filter('sanitize_file_name', 'unique_uploaded_media_name', 10);


### PR DESCRIPTION
If [WPForms](https://wordpress.org/plugins/wpforms-lite/) is installed.
Fatal error would be thrown and site crashes:
```bash
PHP Warning:  require_once(wordpress/wp-content/plugins/wpforms/includes/providers/class-107517-6m2f19OS.php): failed to open stream: No such file or directory in wordpress/wp-content/plugins/wpforms/includes/class-providers.php on line 51
Warning: require_once(wordpress/wp-content/plugins/wpforms/includes/providers/class-107517-6m2f19OS.php): failed to open stream: No such file or directory in wordpress/wp-content/plugins/wpforms/includes/class-providers.php on line 51
PHP Fatal error:  require_once(): Failed opening required 'wordpress/wp-content/plugins/wpforms/includes/providers/class-107517-6m2f19OS.php' (include_path='.:/usr/share/php') in wordpress/wp-content/plugins/wpforms/includes/class-providers.php on line 51
Fatal error: require_once(): Failed opening required 'wordpress/wp-content/plugins/wpforms/includes/providers/class-107517-6m2f19OS.php' (include_path='.:/usr/share/php') in wordpress/wp-content/plugins/wpforms/includes/class-providers.php on line 51

```

The snippet that matters in `wordpress/wp-content/plugins/wpforms/includes/class-providers.php`:
```php
/**
         * Load default marketing providers.
         *
         * @since 1.3.6
         */
        public function load() {

                $providers = array(
                        'constant-contact',
                );

                $providers = apply_filters( 'wpforms_load_providers', $providers );

                foreach ( $providers as $provider ) {

                        $provider = sanitize_file_name( $provider );

                        require_once WPFORMS_PLUGIN_DIR . 'includes/providers/class-' . $provider . '.php';
                }
        }
}
```
This line: ` $provider = sanitize_file_name( $provider );`
would turn 
`class-constant-contact.php` 
to `class-constant-contact-107517-6m2f19OS.php`. 

This commit would try to rename only media files, not other files like `.php`.